### PR TITLE
Add +cross flag to .cabal file

### DIFF
--- a/alsa-mixer.cabal
+++ b/alsa-mixer.cabal
@@ -18,10 +18,16 @@ Source-repository head
   Type:     git
   Location: https://github.com/ttuegel/alsa-mixer.git
 
+Flag cross
+  Description:         Set this flag if cross-compiling
+  Default:             False
+  Manual:              True
+
 Library
   Exposed-modules:     Sound.ALSA.Mixer
   Other-modules:       Sound.ALSA.Mixer.Internal
-  Build-tools:         c2hs
+  if !flag(cross)
+      Build-tools:     c2hs
   Extra-libraries:     asound
   Build-depends:       base == 4.*,
                        alsa-core == 0.5.*,


### PR DESCRIPTION
This adds a `cross` flag so that `cabal` doesn't try to build `c2hs` (and thus doesn't try to build `happy`) when cross-compiling. This simplifies cross-compilation of [xmonad-volume](http://hackage.haskell.org/package/xmonad-volume), among other things. 