### PR TITLE
Updated alsa-mixer.cabal

### DIFF
--- a/alsa-mixer.cabal
+++ b/alsa-mixer.cabal
@@ -1,34 +1,35 @@
-Name:                alsa-mixer
-Version:             0.3.0
-Synopsis:            Bindings to the ALSA simple mixer API.
-Description:         This package provides bindings to the ALSA simple mixer API.
-License:             BSD3
-License-file:        LICENSE
-Author:              Thomas Tuegel <ttuegel@mailbox.org>
-Maintainer:          Thomas Tuegel <ttuegel@mailbox.org>
-Copyright:           2014-2018 Thomas Tuegel
-Category:            Sound
-Build-type:          Simple
-Cabal-version:       >=1.6
-Homepage:            https://github.com/ttuegel/alsa-mixer
-Bug-reports:         https://github.com/ttuegel/alsa-mixer/issues
-Extra-source-files:  changelog
+name:               alsa-mixer
+version:            0.3.0
+synopsis:           Bindings to the ALSA simple mixer API.
+description:
+  This package provides bindings to the ALSA simple mixer API.
 
-Source-repository head
-  Type:     git
-  Location: https://github.com/ttuegel/alsa-mixer.git
+license:            BSD3
+license-file:       LICENSE
+author:             Thomas Tuegel <ttuegel@mailbox.org>
+maintainer:         Thomas Tuegel <ttuegel@mailbox.org>
+copyright:          2014-2021 Thomas Tuegel
+category:           Sound
+build-type:         Simple
+cabal-version:      >=1.8
+homepage:           https://github.com/ttuegel/alsa-mixer
+bug-reports:        https://github.com/ttuegel/alsa-mixer/issues
+extra-source-files: changelog
 
-Flag cross
-  Description:         Set this flag if cross-compiling
-  Default:             False
-  Manual:              True
+source-repository head
+  type:     git
+  location: https://github.com/ttuegel/alsa-mixer.git
 
-Library
-  Exposed-modules:     Sound.ALSA.Mixer
-  Other-modules:       Sound.ALSA.Mixer.Internal
-  if !flag(cross)
-      Build-tools:     c2hs
-  Extra-libraries:     asound
-  Build-depends:       base == 4.*,
-                       alsa-core == 0.5.*,
-                       unix >= 2.6 && < 3
+flag cross
+  description: Set this flag if cross-compiling
+  default:     False
+  manual:      True
+
+library
+  exposed-modules: Sound.ALSA.Mixer
+  other-modules:   Sound.ALSA.Mixer.Internal
+  extra-libraries: asound
+  build-depends:
+      alsa-core  >=0.5 && <0.6
+    , base       >=4   && <5
+    , unix       >=2.6 && <3


### PR DESCRIPTION
- Changed field `cabal-version` from `>=1.6` to `>=1.8` to suppress a warning from `cabal`
- Field `built-tools` is removed since `cabal 3.0` and it's no longer needed.
- Updated copyright year
- Reformatted the file with `cabal-fmt`