### PR TITLE
Avoid returning [NULL] if mixer elements are empty

### DIFF
--- a/Sound/ALSA/Mixer/Internal.chs
+++ b/Sound/ALSA/Mixer/Internal.chs
@@ -167,14 +167,13 @@ getId e = do
 
 elements :: Mixer -> IO [(SimpleElementId, SimpleElement)]
 elements fMix = do
-    pFirst <- sndMixerFirstElem fMix
-    pLast <- sndMixerLastElem fMix
-    es <- elements' pFirst [] pLast
+    pFirst <- sndMixerFirstElem fMix -- Returns null if list of mixer-elems is empty.
+    es <- elements' pFirst []
     mapM (simpleElement fMix) es
-  where elements' pThis xs pLast | pThis == pLast = return $ pThis : xs
-                                 | otherwise = do
-                                     pNext <- sndMixerElemNext pThis
-                                     elements' pNext (pThis : xs) pLast
+  where elements' pThis xs | pThis == nullPtr = return xs
+                           | otherwise = do
+                               pNext <- sndMixerElemNext pThis
+                               elements' pNext (pThis : xs)
 
 -----------------------------------------------------------------------
 -- simpleElement


### PR DESCRIPTION
This PR adds a check to avoid dereferencing NULL inside `simpleElement`.

If the given mixer's element list is empty, both [snd_mixer_first_elem](https://github.com/michaelwu/alsa-lib/blob/afb2fbd0e554e42e51325c3197a176ea96a74203/src/mixer/mixer.c#L786) and [snd_mixer_last_elem](https://github.com/michaelwu/alsa-lib/blob/afb2fbd0e554e42e51325c3197a176ea96a74203/src/mixer/mixer.c#L799) will return `NULL`, which means `elements'` will return `nullPtr : [] == [nullPtr]`.

This is triggered e.g. [here](https://codeberg.org/xmobar/xmobar/issues/659), when xmobar will crash immediately after system start or resume from suspend, when mixer elements are not available yet for a short time.